### PR TITLE
Consistent suite.rc indentation + update copyright

### DIFF
--- a/kafka/consumer/suite.rc
+++ b/kafka/consumer/suite.rc
@@ -27,20 +27,20 @@
         an = cylc_kafka_consumer( \
                  kafka_server={{KAFKA_SERVER}}, kafka_topic={{KAFKA_TOPIC}}, \
                  message=system:{{SYSTEM}} point:%(point)s data:<.*analysis.*>, \
-            group_id=an{{GROUP_ID_PREFIX}}(id)s):PT10S
+                 group_id=an{{GROUP_ID_PREFIX}}(id)s):PT10S
         # Trigger off of availability of "forecast" files:
         # Don't quote the function arguments here.
         fc = cylc_kafka_consumer( \
-            kafka_server={{KAFKA_SERVER}}, kafka_topic={{KAFKA_TOPIC}}, \
-            message=system:{{SYSTEM}} point:%(point)s data:<.*forecast.*>, \
-            group_id=fc{{GROUP_ID_PREFIX}}%(id)s):PT10S
-   [[dependencies]]
+                 kafka_server={{KAFKA_SERVER}}, kafka_topic={{KAFKA_TOPIC}}, \
+                 message=system:{{SYSTEM}} point:%(point)s data:<.*forecast.*>, \
+                 group_id=fc{{GROUP_ID_PREFIX}}%(id)s):PT10S
+    [[dependencies]]
         [[[P1Y]]]
-           graph = """@an => proc_an
-                      @fc => proc_fc
-                      pre => proc_an & proc_fc => publish
-                      # Make sure products are published in correct order:
-                      publish[-P1Y] => publish"""
+            graph = """@an => proc_an
+                       @fc => proc_fc
+                       pre => proc_an & proc_fc => publish
+                       # Make sure products are published in correct order:
+                       publish[-P1Y] => publish"""
 [runtime]
     [[pre]]
         #...

--- a/kafka/producer/suite.rc
+++ b/kafka/producer/suite.rc
@@ -16,20 +16,24 @@
 [scheduling]
     initial cycle point = 3010
     final cycle point = 3015
-   [[dependencies]]
-      [[[P1Y]]]
-          graph = "pre & forecast[-P1Y] => forecast => post"
+    [[dependencies]]
+        [[[P1Y]]]
+            graph = "pre & forecast[-P1Y] => forecast => post"
 [runtime]
-   [[root]]
-      pre-script = sleep 10
-      [[[events]]]
-          # (don't use single quotes here)
-          custom handler = cylc_kafka_producer.py \
-                               {{KAFKA_SERVER}} {{KAFKA_TOPIC}} "system={{SYSTEM}}" \
-                                   "point=%(point)s" "data=%(message)s"
-   [[pre]]
-      script = cylc message -p CUSTOM /data/analysis-${CYLC_TASK_CYCLE_POINT}.nc
-   [[forecast]]
-      script = cylc message -p CUSTOM /data/forecast-${CYLC_TASK_CYCLE_POINT}.nc
-   [[post]]
-      script = cylc message -p CUSTOM /data/products-${CYLC_TASK_CYCLE_POINT}.nc
+    [[root]]
+        pre-script = sleep 10
+        [[[events]]]
+            # (don't use single quotes here)
+            custom handler = cylc_kafka_producer.py \
+                                 {{KAFKA_SERVER}} {{KAFKA_TOPIC}} \
+                                 "system={{SYSTEM}}" \
+                                 "point=%(point)s" "data=%(message)s"
+    [[pre]]
+        script = """
+cylc message -p CUSTOM /data/analysis-${CYLC_TASK_CYCLE_POINT}.nc"""
+    [[forecast]]
+        script = """
+cylc message -p CUSTOM /data/forecast-${CYLC_TASK_CYCLE_POINT}.nc"""
+    [[post]]
+        script = """
+cylc message -p CUSTOM /data/products-${CYLC_TASK_CYCLE_POINT}.nc"""

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
+
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
I was looking through the repo, as I hope to add some in further xtrigger examples soon, & I noticed some minor aspects that could be tidied:
* the ``setup.py`` has an outdated copyright; 
* indentation in the Kafka ``suite.rc`` examples is inconsistent.

Here's a quick PR to amend those.